### PR TITLE
Abstract out ajax calls and support rendering with templates.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,13 +1,32 @@
+import request from './lib/request';
+
 import CountryApi from './api/countries';
 import ProductApi from './api/product';
 import ProductAttributesApi from './api/product-attributes';
 import SearchApi from './api/search';
 import CartApi from './api/cart';
 
+let internals = {};
+
+/**
+ * Convenience function to request a page via ajax
+ *
+ * @param url
+ * @param options
+ * @param callback
+ */
+internals.getPage = function (url, options, callback) {
+    request(url, {
+        method: 'GET',
+        requestOptions: options
+    }, callback);
+};
+
 export default {
     country: new CountryApi(),
     productAttributes: new ProductAttributesApi(),
     product: new ProductApi(),
     search: new SearchApi(),
-    cart: new CartApi()
+    cart: new CartApi(),
+    getPage: internals.getPage
 };

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,9 +1,6 @@
 import $ from 'jquery';
 import _ from 'lodash';
-
-const allowedMethods = ['GET', 'POST', 'PUT', 'DELETE'];
-
-let internals = {};
+import request from '../lib/request';
 
 export default class
 {
@@ -13,75 +10,23 @@ export default class
      */
     constructor(version) {
         this.remoteVersion = version || 'v1';
-        this.baseEndPoint = '/remote/';
-        this.endPoint = '/';
-    }
-
-    /**
-     * Gets the current remote version
-     *
-     * @returns {string}
-     */
-    getRemoteVersion() {
-        return this.remoteVersion;
-    }
-
-    /**
-     * Set a different remote version
-     *
-     * @param {string} version
-     */
-    setRemoteVersion(version) {
-        this.remoteVersion = version
+        this.baseEndpoint = '/remote/';
     }
 
     /**
      *
-     * @param {String} url
+     * @param {String} endpoint
      * @param {String} method ['GET', 'POST', 'PUT', 'DELETE']
      * @param {Object} options
      * @param {Function} callback
      */
-    makeRequest(url, method, options, callback) {
-        let remoteUrl = this.baseEndPoint + this.getRemoteVersion() + url,
-            // success
-            success = (data) => {
-                callback(null, data);
-            },
-            // error
-            error = (XHR, textStatus, err) => {
-                callback(err);
-            },
-            defaultOptions = {
-                params: {},
-                headers: {}
-            };
+    makeRequest(endpoint, method, options, callback) {
+        let remoteUrl = this.baseEndpoint + this.remoteVersion + endpoint;
 
-        options = _.assign({}, defaultOptions, options);
-
-        // Not a valid method
-        if (!internals.isValidHTTPMethod(method)) {
-            return callback('Not a valid HTTP method');
-        }
-
-        // make ajax request using jquery
-        $.ajax({
+        request(remoteUrl, {
             method: method,
-            url: remoteUrl,
-            success: success,
-            error: error,
-            data: options.params,
-            headers: options.headers
-        });
+            remote: true,
+            requestOptions: options
+        }, callback);
     }
 }
-
-/**
- * Checks whether or not the current method passed in is valid
- *
- * @param {string} method
- * @returns {boolean}
- */
-internals.isValidHTTPMethod = (method) => {
-    return allowedMethods.indexOf(method) !== -1;
-};

--- a/src/api/countries.js
+++ b/src/api/countries.js
@@ -11,7 +11,7 @@ export default class extends Base
         super();
 
         // set up class variables
-        this.endPoint = '/country-states/';
+        this.endpoint = '/country-states/';
     }
 
     /**
@@ -22,14 +22,14 @@ export default class extends Base
      * @param {Function} callback
      */
     getById(countryId, callback) {
-        let url = this.endPoint + countryId;
+        let url = this.endpoint + countryId;
 
         Hooks.emit('country-remote', {id: countryId});
         this.makeRequest(url, 'GET', {}, callback);
     }
 
     getByName(countryName, callback) {
-        let url = this.endPoint + countryName;
+        let url = this.endpoint + countryName;
 
         Hooks.emit('country-remote', {name: countryName});
         this.makeRequest(url, 'GET', {}, callback);

--- a/src/api/product-attributes.js
+++ b/src/api/product-attributes.js
@@ -12,7 +12,7 @@ export default class extends Base
         super();
 
         // set up class variables
-        this.endPoint = '/product-attributes/';
+        this.endpoint = '/product-attributes/';
     }
 
     /**
@@ -23,7 +23,7 @@ export default class extends Base
      */
     optionChange(options, productId, callback)
     {
-        let url = this.endPoint + productId,
+        let url = this.endpoint + productId,
             params = options;
 
         Hooks.emit('product-options-change-remote', productId);

--- a/src/api/product.js
+++ b/src/api/product.js
@@ -10,7 +10,7 @@ export default class extends Base
         // call parent
         super();
 
-        this.endPoint = '/product/';
+        this.endpoint = '/product/';
     }
 
     /**
@@ -21,7 +21,7 @@ export default class extends Base
      */
     getById(productId, params, callback)
     {
-        let url = this.endPoint + productId;
+        let url = this.endpoint + productId;
 
         if (typeof params === 'function') {
             callback = params;

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -12,7 +12,7 @@ export default class extends Base
         super();
 
         // set up class variables
-        this.endPoint = '/search';
+        this.endpoint = '/search';
     }
 
     /**
@@ -31,6 +31,6 @@ export default class extends Base
         options.params.search_query = encodeURIComponent(query);
 
         Hooks.emit('search-quick-remote', options);
-        this.makeRequest(this.endPoint, 'GET', options, callback);
+        this.makeRequest(this.endpoint, 'GET', options, callback);
     }
 }

--- a/src/hooks/account.js
+++ b/src/hooks/account.js
@@ -6,6 +6,7 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
-
+        // call parent
+        super();
     }
 }

--- a/src/hooks/cart.js
+++ b/src/hooks/cart.js
@@ -7,6 +7,9 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
+        // call parent
+        super();
+
         this.itemAdd();
     }
 

--- a/src/hooks/country.js
+++ b/src/hooks/country.js
@@ -6,6 +6,7 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
-
+        // call parent
+        super();
     }
 }

--- a/src/hooks/currency-selector.js
+++ b/src/hooks/currency-selector.js
@@ -7,6 +7,9 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
+        // call parent
+        super();
+
         this.currencySelector();
     }
 

--- a/src/hooks/faceted-search.js
+++ b/src/hooks/faceted-search.js
@@ -7,6 +7,9 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
+        // call parent
+        super();
+
         this.searchEvents();
     }
 

--- a/src/hooks/product.js
+++ b/src/hooks/product.js
@@ -6,6 +6,7 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
-
+        // call parent
+        super();
     }
 }

--- a/src/hooks/search.js
+++ b/src/hooks/search.js
@@ -7,6 +7,9 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
+        // call parent
+        super();
+
         this.quickSearch();
     }
 

--- a/src/hooks/sort-by.js
+++ b/src/hooks/sort-by.js
@@ -7,6 +7,9 @@ export default class extends BaseHooks {
      * @Constructor
      */
     constructor() {
+        // call parent
+        super();
+
         this.sortByEvents();
     }
 

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,0 +1,106 @@
+import $ from 'jquery';
+import _ from 'lodash';
+
+const allowedMethods = ['GET', 'POST', 'PUT', 'DELETE'];
+
+let internals = {};
+
+export default function (url, options, callback) {
+    let defaultOptions = {
+            method: 'GET',
+            remote: false,
+            requestOptions: {
+                params: {},
+                config: {},
+                template: []
+            }
+        },
+        usingTemplates = false,
+        usingSections = false,
+        templates = [],
+        headers;
+
+    options = _.assign({}, defaultOptions, options);
+
+    // Not a valid method
+    if (!internals.isValidHTTPMethod(options.method)) {
+        return callback(new Error('Not a valid HTTP method'));
+    }
+
+    if (_.isPlainObject(options.requestOptions.template)) {
+        usingSections = true;
+        templates = _.reduce(options.requestOptions.template, (acc, template) => {
+            acc.push(template);
+
+            return acc;
+        }, []);
+    } else if (_.isString(options.requestOptions.template)) {
+        templates = [options.requestOptions.template]
+    } else if (_.isArray(options.requestOptions.template) && options.requestOptions.template.length > 0) {
+        templates = options.requestOptions.template;
+    }
+
+    headers = {
+        'stencil-config': JSON.stringify(options.requestOptions.config)
+    };
+
+    if (templates.length > 0) {
+        usingTemplates = true;
+
+        headers['stencil-options'] = JSON.stringify({render_with: templates.join(',')})
+    }
+
+    // make ajax request using jquery
+    $.ajax({
+        method: options.method,
+        url: url,
+        success: (response) => {
+            let ret,
+                content = options.remote ? response.content : response;
+
+            if (usingTemplates) {
+                // Remove the `components` prefix from the response if it's an object
+                if (_.isObject(content)) {
+                    content = _.mapKeys(content, (val, key) => {
+                        return key.replace(/^components\//, '');
+                    });
+                }
+
+                // If using "sections", morph the content into the arbitrary keys => content object.
+                if (usingSections) {
+                    let flippedSections = _.invert(options.requestOptions.template);
+
+                    content = _.mapKeys(content, (val, key) => {
+                        return flippedSections[key];
+                    });
+                }
+
+                if (options.remote) {
+                    ret = response;
+                    ret.content = content;
+                } else {
+                    ret = content;
+                }
+            } else {
+                ret = response;
+            }
+
+            callback(null, ret);
+        },
+        error: (XHR, textStatus, err) => {
+            callback(err);
+        },
+        data: options.requestOptions.params,
+        headers: headers
+    });
+}
+
+/**
+ * Checks whether or not the current method passed in is valid
+ *
+ * @param {string} method
+ * @returns {boolean}
+ */
+internals.isValidHTTPMethod = (method) => {
+    return allowedMethods.indexOf(method) !== -1;
+};


### PR DESCRIPTION
Abstract out the ajax requests to a `Request` lib.  It will handle ajax calls without specifying templates, or if you specify one template, array of templates, or an object of templates with arbitrary keys.
