### PR TITLE
BIG-21501 - EU Cookie warning (Bugfix)

### DIFF
--- a/src/api/cookie.js
+++ b/src/api/cookie.js
@@ -52,8 +52,10 @@ export default class extends Base
                         document.cookie = cookieStr;
                     });
                 } else {
-                    document.cookie = cookieStr;
-                    alert(response.data.PrivacyCookieNotification);
+                    const confirmed = confirm(response.data.PrivacyCookieNotification);
+                    if (confirmed) {
+                        document.cookie = cookieStr;
+                    }
                 }
             }
         });

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -48,7 +48,7 @@ class Hooks {
     emit(hookName) {
         const hook = internals.parseHooks(hookName);
 
-        return hook.emit.apply(arguments);
+        return hook.emit.apply(hook, arguments);
     }
 }
 


### PR DESCRIPTION
BIG-21501 - EU Cookie warning (Bugfix)
- Added hook context to emitter, this was causing the cookie listener not to receive events.
- Changed alert to confirm, in the case of default not being prevented.
