### PR TITLE
MERC-354 update package.json for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "lib": "src"
     },
     "dependencies": {
-      "asyncly/EventEmitter2": "github:asyncly/EventEmitter2@0.4.14",
+      "asyncly/EventEmitter2": "github:asyncly/EventEmitter2@^0.4.14",
       "jquery": "github:components/jquery@2.1.4"
     },
     "devDependencies": {


### PR DESCRIPTION
```
warn Error on processPackageConfig
     Package.json dependency asyncly/EventEmitter2 set to github:asyncly/EventEmitter2@0.4.14, which is not a valid dependency format for npm.
```

@mickr @mcampa @bc-ejoe 
