### PR TITLE
DATA-2350:In-store search analytics shows no search keywords with res…

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -11,7 +11,7 @@ export default class extends Base
         super(version);
 
         // set up class variables
-        this.endpoint = '/search.php?search_query=';
+        this.endpoint = '/search.php?action=AjaxSearch&search_query=';
     }
 
     /**


### PR DESCRIPTION
Without this parameter request is going through a different action in controller that would save multiple search terms while user is typing search word. This is really bad for our search statistics. All ajax requests outside of stencil have this parameter specified in the call. Here are the images before fix and after

![screen shot 2017-03-29 at 11 54 57 am](https://cloud.githubusercontent.com/assets/9043352/24474820/b38afc86-1482-11e7-9f95-f6f42752f0c7.png)
 
![screen shot 2017-03-29 at 11 55 48 am](https://cloud.githubusercontent.com/assets/9043352/24474824/b975d6f2-1482-11e7-90c3-35237c19c3ca.png)

@bigcommerce/stencil-team 