### PR TITLE
Revert "DATA-2350:In-store search analytics shows no search keywords with res…"

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -11,7 +11,7 @@ export default class extends Base
         super(version);
 
         // set up class variables
-        this.endpoint = '/search.php?action=AjaxSearch&search_query=';
+        this.endpoint = '/search.php?search_query=';
     }
 
     /**


### PR DESCRIPTION
Reverts bigcommerce/stencil-utils#67

Since it broke search autocomplete in cornerstone themes.

@bc-nataliya @bigcommerce/stencil-team @aleachjr 