### PR TITLE
STRF-4391 - Migrate jQuery from 2->3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "main": "src/main.js",
   "license": "BSD-4-Clause",
   "author": "Bigcommerce",
-  "description": "Utility library used by Bigcommerce Stencil Framework themes",
+  "description": "Utility library used by BigCommerce Stencil Framework themes",
   "repository": {
     "type": "git",
     "url": "git://github.com/bigcommerce/stencil-utils.git"
   },
   "dependencies": {
     "eventemitter2": "^0.4.14",
-    "jquery": "^2.2.1",
+    "jquery": "^3.3.1",
     "query-string": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### WHAT
* upgrades jquery from 2.x to 3.x

### WHY
* vulnerability in 2.x (https://jira.bigcommerce.com/browse/STRF-4391)

### TESTING
* unit tests + https://github.com/bigcommerce/cornerstone/pull/1162
* regression: https://launchbay.bigcommerce.net/projects/1/releases/47713

ping @bigcommerce/storefront-team 