### PR TITLE
Callback with error on getCartQuantity method

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -25,6 +25,9 @@ export default class extends Base {
      */
     getCartQuantity(callback) {
         this.getCart({}, (err, response) => {
+            if (err) {
+                return callback(err);
+            }
             let quantity = 0;
             if (response.length) {
                 const cart = response[0];
@@ -38,7 +41,7 @@ export default class extends Base {
                 const giftCertificateQuantity = cart.lineItems.giftCertificates.length;
                 quantity = lineItemQuantities + giftCertificateQuantity;
             }
-            callback(quantity);
+            callback(null, quantity);
         });
     }
 


### PR DESCRIPTION
@mattolson pointed out that we should have made this error-first, so I'm updating that.

Unfortunately, this breaks the interface for this function, requiring a 3.0; chances are very few people are affected by this, but you can't be too careful.