### PR TITLE
Add methods to check if storage is supported

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,7 @@
 import ImageTool from './tools/image';
+import StorageTools from './tools/storage';
 
 export default {
     image: new ImageTool(),
+    storage: new StorageTools(),
 };

--- a/src/tools/storage.js
+++ b/src/tools/storage.js
@@ -1,0 +1,34 @@
+export default class {
+    /**
+     * Check if a storage type (like localStorage or sessionStorage) is available for use
+     * https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Testing_for_availability
+     * @param type
+     * @returns boolean
+     */
+    storageAvailable(type) {
+        const storage = window[type];
+        try {
+            const x = '__storage_test__';
+            storage.setItem(x, x);
+            storage.removeItem(x);
+            return true;
+        } catch (e) {
+            return e instanceof DOMException && (
+                    // everything except Firefox
+                e.code === 22 ||
+                // Firefox
+                e.code === 1014 ||
+                // test name field too, because code might not be present
+                // everything except Firefox
+                e.name === 'QuotaExceededError' ||
+                // Firefox
+                e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+                // acknowledge QuotaExceededError only if there's something already stored
+                storage.length !== 0;
+        }
+    }
+
+    localStorageAvailable() {
+        return this.storageAvailable('localStorage');
+    }
+}


### PR DESCRIPTION
Example usage:

```  
console.log(utils.tools.storage.localStorageAvailable());
```

This adds a few methods to check if storage methods are available for use in the browser, so we can react appropriately and gracefully degrade the experience of features that may depend on them.

ping @junedkazi @mattolson 