### PR TITLE
Make sure Cart API calls always use HTTPS when possible.

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -10,6 +10,12 @@ export default class extends Base {
      */
     getCart(options = {}, callback) {
         let url = '/api/storefront/cart';
+
+        // Cart API requests should always be HTTPS. If the window has an HTTPS url to use, use it.
+        if (window.hasOwnProperty('secureBaseUrl')) {
+            url = window.secureBaseUrl + url;
+        }
+
         if (options.includeOptions) {
             url = `${url}?include=lineItems.physicalItems.options,lineItems.digitalItems.options`;
         }

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -72,6 +72,9 @@ export default function (url, opts, callback) {
     $.ajax({
         method: options.method,
         url,
+        xhrFields: {
+            withCredentials: true,
+        },
         contentType: options.requestOptions.formData ? false : 'application/x-www-form-urlencoded; charset=UTF-8',
         processData: !options.requestOptions.formData,
         success: (response) => {


### PR DESCRIPTION
Our Cart API (and presumably all Storefront APIs) require HTTPS.

As not all stores have a private SSL, we needed a means of injecting the HTTPS URL for the store, which we've done by adding it to the window object in https://github.com/bigcommerce/cornerstone/pull/1379

This PR does two things:

- When this window object is detected, build a full URL using the HTTPS base URL (so that Cart API calls keep working on HTTP storefronts)
- Send cookies along with the request even when cross-domain

Potential future improvements:

- Make all stencil-utils requests with HTTPS (this seemed like too much of a risk/testing effort for this PR)

ping @junedkazi @mattolson 