### PR TITLE
Accept options on getCartQuantity to allow baseURL

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -10,10 +10,11 @@ export default class extends Base {
      */
     getCart(options = {}, callback) {
         let url = '/api/storefront/cart';
+
         if (options.includeOptions) {
             url = `${url}?include=lineItems.physicalItems.options,lineItems.digitalItems.options`;
         }
-        this.makeRequest(url, 'GET', {}, true, (err, response) => {
+        this.makeRequest(url, 'GET', options, true, (err, response) => {
             callback(err, response);
         });
     }
@@ -21,10 +22,11 @@ export default class extends Base {
     /**
      * Get a sum of the cart line item quantities
      *
+     * @param options
      * @param {Function} callback
      */
-    getCartQuantity(callback) {
-        this.getCart({}, (err, response) => {
+    getCartQuantity(options = {}, callback) {
+        this.getCart(options, (err, response) => {
             if (err) {
                 return callback(err);
             }

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -13,11 +13,12 @@ function isValidHTTPMethod(method) {
 }
 
 
-export default function (url, opts, callback) {
+export default function (relativeUrl, opts, callback) {
     const defaultOptions = {
         method: 'GET',
         remote: false,
         requestOptions: {
+            baseUrl: null,
             formData: null,
             params: {},
             config: {},
@@ -68,10 +69,18 @@ export default function (url, opts, callback) {
         });
     }
 
+    let url = relativeUrl;
+    if (options.requestOptions.baseUrl) {
+        url = `${options.requestOptions.baseUrl}${url}`;
+    }
+
     // make ajax request using jquery
     $.ajax({
         method: options.method,
         url,
+        xhrFields: {
+            withCredentials: true,
+        },
         contentType: options.requestOptions.formData ? false : 'application/x-www-form-urlencoded; charset=UTF-8',
         processData: !options.requestOptions.formData,
         success: (response) => {


### PR DESCRIPTION
We need a means of accepting options on getCartQuantity so we can force it to use the store's HTTPS URL.

We didn't like the approach in https://github.com/bigcommerce/stencil-utils/pull/92 (using globals), so instead accepting an options object as a lot of other methods in this library do.

Intended to pair with https://github.com/bigcommerce/cornerstone/pull/1379

May require a 4.0.0 since it breaks the contract for getCartQuantity()

Example usage:

```
    utils.api.cart.getCartQuantity({ baseUrl: 'https://secure-domain.com' }, (err, qty) => {
        console.log(qty);
    });
```

Changeset:

1. Add options argument to getCartQuantity()
2. If a baseUrl property is supplied as part of options, make it construct a full URL in getCart using the base URL (intended to accept the store's HTTPS URL)
3. Update the underlying requests library to send credentials cross-domain (so stores on HTTP can get their HTTPS cart from their shared SSL hostname, if necessary)

ping @mattolson @junedkazi 