### PR TITLE
Fix baseUrl not working with getCartQuantity

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -70,7 +70,7 @@ export default function (relativeUrl, opts, callback) {
     }
 
     let url = relativeUrl;
-    if (options.requestOptions.baseUrl) {
+    if (options.requestOptions.baseUrl.length > 0) {
         url = `${options.requestOptions.baseUrl}${url}`;
     }
 


### PR DESCRIPTION
Use a better means of detecting this object (especially since it has default values above) so it actually works.