### PR TITLE
Accept cart ID to explicitly request a cart by ID

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -11,6 +11,10 @@ export default class extends Base {
     getCart(options = {}, callback) {
         let url = '/api/storefront/cart';
 
+        if (options.cartId) {
+            url = `/api/storefront/carts/${options.cartId}`;
+        }
+
         if (options.includeOptions) {
             url = `${url}?include=lineItems.physicalItems.options,lineItems.digitalItems.options`;
         }


### PR DESCRIPTION
We'll continue to support requesting the "current cart" without an ID, but also allow accepting an explicit ID. This is unnecessary for now (as a given shopper can have at most one cart), but might be useful in the future.