### PR TITLE
Add support for inherent width resizing

### DIFF
--- a/src/tools/image.js
+++ b/src/tools/image.js
@@ -1,6 +1,7 @@
 export default class {
     getSrc(path, dimensions) {
-        const sizeRegex = /^(\d+?)x(\d+?)$/g;
+        // Regex to test size string is of the form 123x123 or 100w
+        const sizeRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/g;
         let size;
 
         if (typeof(dimensions) === 'object') {


### PR DESCRIPTION
Updating this regex to allow "100w" as well as "100x100"

Valid values include:

`123x123`
`1x100`
`100x1`
`1w`
`100w`
`999w`

Invalid values:
`abc`
`100`
`100x`
And anything else outlandish.

Pairs with https://github.com/bigcommerce/bigcommerce/pull/30583

CC @bigcommerce/storefront-team 