### PR TITLE
Remove node 6 from travis, add node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
+  - 12
 sudo: false
 install:
   - npm install


### PR DESCRIPTION
Node 6 is deprecated, and we have aspirations to start using node 12 soon.