### PR TITLE
Exempt cart line items without a parent ID (bundled items) from the quantity count

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -65,13 +65,14 @@ export default class extends Base {
                 return callback(err);
             }
             let quantity = 0;
-            if (response.length) {
+            if (response) {
                 const cart = response;
                 const lineItemQuantities = [
                     cart.lineItems.physicalItems,
                     cart.lineItems.digitalItems,
                     cart.lineItems.customItems,
                 ].reduce((a, b) => a.concat(b))
+                    .filter(lineItem => !lineItem.parentId)
                     .map(lineItem => lineItem.quantity)
                     .reduce((accumulator, lineItemQuantity) => accumulator + lineItemQuantity);
                 const giftCertificateQuantity = cart.lineItems.giftCertificates.length;


### PR DESCRIPTION
This should make the quantity count match what is generated in the Stencil context, by exempted line items that are in the cart due to bundled (Product Pick List options)

Also fixes a bug where the cart quantity was defaulting to 0 due to use of `response.length`.