### PR TITLE
Fix uncaught TypeError when only gift certificates

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -74,7 +74,7 @@ export default class extends Base {
                 ].reduce((a, b) => a.concat(b))
                     .filter(lineItem => !lineItem.parentId)
                     .map(lineItem => lineItem.quantity)
-                    .reduce((accumulator, lineItemQuantity) => accumulator + lineItemQuantity);
+                    .reduce((accumulator, lineItemQuantity) => accumulator + lineItemQuantity, 0);
                 const giftCertificateQuantity = cart.lineItems.giftCertificates.length;
                 quantity = lineItemQuantities + giftCertificateQuantity;
             }


### PR DESCRIPTION
When there are only gift certificates in the cart, `getCartQuantity` calls `reduce` without an initializer. This throws `Uncaught TypeError: Reduce of empty array with no initial value`. Fixing this only requires putting an initial value, in this case 0.