### PR TITLE
fix: STRF-8599 Passed down the target (current) element from the general subscribe event handlers

### DIFF
--- a/src/hooks/base.js
+++ b/src/hooks/base.js
@@ -5,7 +5,7 @@ export default class extends EventEmitter {
         document.addEventListener(eventName, function (e) {
             for (let target = e.target; target && target !== this; target = target.parentNode) {
                 if (target.matches(elementSelector)) {
-                    handler.call(target, e);
+                    handler.call(target, e, target);
                     break;
                 }
             }

--- a/src/hooks/cart.js
+++ b/src/hooks/cart.js
@@ -13,8 +13,8 @@ export default class extends BaseHooks {
     }
 
     itemAdd() {
-        this.subscribe('submit', '[data-cart-item-add]', (event) => {
-            this.emit('cart-item-add', event, event.target);
+        this.subscribe('submit', '[data-cart-item-add]', (event, target) => {
+            this.emit('cart-item-add', event, target);
         });
     }
 }

--- a/src/hooks/faceted-search.js
+++ b/src/hooks/faceted-search.js
@@ -13,12 +13,12 @@ export default class extends BaseHooks {
     }
 
     searchEvents() {
-        this.subscribe('click', '[data-faceted-search-facet]', (event) => {
-            this.emit('facetedSearch-facet-clicked', event);
+        this.subscribe('click', '[data-faceted-search-facet]', (event, target) => {
+            this.emit('facetedSearch-facet-clicked', event, target);
         });
 
-        this.subscribe('submit', '[data-faceted-search-range]', (event) => {
-            this.emit('facetedSearch-range-submitted', event);
+        this.subscribe('submit', '[data-faceted-search-range]', (event, target) => {
+            this.emit('facetedSearch-range-submitted', event, target);
         });
     }
 }

--- a/src/hooks/product.js
+++ b/src/hooks/product.js
@@ -13,8 +13,8 @@ export default class extends BaseHooks {
     }
 
     optionsChange() {
-        this.subscribe('change', '[data-product-option-change]', (event) => {
-            this.emit('product-option-change', event, event.target);
+        this.subscribe('change', '[data-product-option-change]', (event, target) => {
+            this.emit('product-option-change', event, target);
         });
     }
 }

--- a/src/hooks/search.js
+++ b/src/hooks/search.js
@@ -13,8 +13,8 @@ export default class extends BaseHooks {
     }
 
     quickSearch() {
-        this.subscribe('input', '[data-search-quick]', (event) => {
-            this.emit('search-quick', event);
+        this.subscribe('input', '[data-search-quick]', (event, target) => {
+            this.emit('search-quick', event, target);
         });
     }
 }

--- a/src/hooks/sort-by.js
+++ b/src/hooks/sort-by.js
@@ -23,15 +23,15 @@ export default class extends BaseHooks {
     }
 
     sortByEvents() {
-        this.subscribe('submit', '[data-sort-by]', (event) => {
-            this.emit('sortBy-submitted', event);
+        this.subscribe('submit', '[data-sort-by]', (event, target) => {
+            this.emit('sortBy-submitted', event, target);
         });
 
-        this.subscribe('change', '[data-sort-by] select', (event) => {
-            this.emit('sortBy-select-changed', event);
+        this.subscribe('change', '[data-sort-by] select', (event, target) => {
+            this.emit('sortBy-select-changed', event, target);
 
-            if (!event.isDefaultPrevented()) {
-                event.currentTarget.closest('form').submit();
+            if (!event.isDefaultPrevented) {
+                target.closest('form').submit();
             }
         });
     }


### PR DESCRIPTION
Some elements on the cornerstone couldn't rely on the currentTarget from the event, because .subscribe() method adds event handler on the document. So the idea is to pass down through the eventemitter not only the event, but also the currentTarget element. 