### PR TITLE
Release 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-utils",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "main": "src/main.js",
   "license": "BSD-4-Clause",
   "author": "Bigcommerce",


### PR DESCRIPTION
Bumping version, cause https://github.com/bigcommerce/stencil-utils/pull/136 blocks from cornerstone release

cc @junedkazi 