### PR TITLE
Send x-requested-with with requests

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -51,6 +51,7 @@ export default function (relativeUrl, opts, callback) {
         'stencil-config': options.requestOptions.config ? JSON.stringify(options.requestOptions.config) : '{}',
         'stencil-options': '{}',
         'x-xsrf-token': window.BCData && window.BCData.csrf_token ? window.BCData.csrf_token : '',
+        'x-requested-with': 'stencil-utils',
     };
 
     if (!isValidHTTPMethod(options.method)) {


### PR DESCRIPTION
Stencil relies on the `x-requested-with` header to power ajax detection. Adding this back in since it stopped being sent when we switched to `fetch`.