### PR TITLE
fix: DATA-10695 Rename cart_value field to product_value for BODL cart events

### DIFF
--- a/src/bodl/emitters/cart.js
+++ b/src/bodl/emitters/cart.js
@@ -26,7 +26,8 @@ class Cart extends Base {
             return {
                 channel_id: response.data.channel_id,
                 currency: response.data.currency,
-                cart_value: response.data.cart_value,
+                // TODO: Remove cart_value once bcapp PR is deployed
+                product_value: response.data.product_value || response.data.cart_value,
                 line_items: response.data.line_items,
             };
         }


### PR DESCRIPTION
## What? [DATA-10695](https://bigcommercecloud.atlassian.net/browse/DATA-10695)
Per title

## Why?
Product requirement. [Related document](https://docs.google.com/document/d/13qlYa9gtuVcjs2iBZ-jWP74W1GPRQw9J496t7QYbbJg/edit#heading=h.7ukms7o1890s). See `cart_product_added` and `cart_product_removed` events. (See the `cart_value` field is renamed to `product_value`)

[DATA-10695]: https://bigcommercecloud.atlassian.net/browse/DATA-10695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ