### PR TITLE
chore: release 6.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-utils",
-  "version": "6.13.0",
+  "version": "6.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-utils",
-  "version": "6.13.0",
+  "version": "6.14.0",
   "main": "src/main.js",
   "license": "BSD-4-Clause",
   "author": "Bigcommerce",


### PR DESCRIPTION
- bump webpack and dependencies
- bump bodl events to 1.9.0

cc @bigcommerce/storefront-team 