### PR TITLE
chore(analytics): DATA-11047 Add line item index and event_id fields for bodl events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-utils",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -10,13 +10,13 @@
       "license": "BSD-4-Clause",
       "dependencies": {
         "eventemitter3": "^4.0.4",
+        "uuid": "^9.0.0",
         "whatwg-fetch": "^3.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.11.4",
         "@babel/plugin-transform-runtime": "^7.12.10",
         "@babel/preset-env": "^7.11.0",
-        "@bigcommerce-labs/bodl-events": "1.9.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.3.0",
         "babel-loader": "^9.1.2",
@@ -1672,20 +1672,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@bigcommerce-labs/bodl-events": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@bigcommerce-labs/bodl-events/1.9.0/5ee3edd05f944e9d4a68c09752bb809dc23aa0e9",
-      "integrity": "sha512-WRoTrximkR1tvbf8XQa0osciuhk6x8hssJ0oSwEsztqFrJFDxaJMcOg+NV1wXdzirXGCpuNFh/mbM8bdrIO2Sg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@types/events": "^3.0.0",
-        "events": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=17.0.0 <19.0.0"
-      }
-    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2558,12 +2544,6 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
-    },
-    "node_modules/@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -8413,6 +8393,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-notifier/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -10977,11 +10967,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12610,16 +12598,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@bigcommerce-labs/bodl-events": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@bigcommerce-labs/bodl-events/1.9.0/5ee3edd05f944e9d4a68c09752bb809dc23aa0e9",
-      "integrity": "sha512-WRoTrximkR1tvbf8XQa0osciuhk6x8hssJ0oSwEsztqFrJFDxaJMcOg+NV1wXdzirXGCpuNFh/mbM8bdrIO2Sg==",
-      "dev": true,
-      "requires": {
-        "@types/events": "^3.0.0",
-        "events": "^3.3.0"
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -13315,12 +13293,6 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
-    },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -17797,6 +17769,13 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true,
+          "optional": true
+        },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -19777,11 +19756,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "eventemitter3": "^4.0.4",
+    "uuid": "^9.0.0",
     "whatwg-fetch": "^3.4.0"
   },
   "devDependencies": {

--- a/src/bodl/emitters/cart.js
+++ b/src/bodl/emitters/cart.js
@@ -1,4 +1,4 @@
-import { isBODLEnabled } from '../helpers';
+import { getEventId, isBODLEnabled } from '../helpers';
 import Base from './base';
 
 class Cart extends Base {
@@ -24,10 +24,11 @@ class Cart extends Base {
     preparePayload(response) {
         if (isBODLEnabled() && !response.data.error) {
             return {
+                event_id: getEventId(),
                 channel_id: response.data.channel_id,
                 currency: response.data.currency,
                 product_value: response.data.product_value,
-                line_items: response.data.line_items,
+                line_items: response.data.line_items.map((item, index) => ({ ...item, index })),
             };
         }
 

--- a/src/bodl/helpers.js
+++ b/src/bodl/helpers.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export const isBODLEnabled = () => typeof window.bodlEvents !== 'undefined';
 
 export const FakeBODLEvents = {
@@ -13,6 +15,8 @@ export const FakeBODLEvents = {
         CREATE: 'create_remove_cart_item',
     },
 };
+
+export const getEventId = () => uuidv4();
 
 export const getBODLEvents = () => {
     if (isBODLEnabled()) {


### PR DESCRIPTION
## What [DATA-11047](https://bigcommercecloud.atlassian.net/browse/DATA-11047)
- Add `index` field into `line_item` for `BODL` events
- Add `event_id` field for `BODL` events

## Why
As per the [requirements](https://docs.google.com/document/d/13qlYa9gtuVcjs2iBZ-jWP74W1GPRQw9J496t7QYbbJg/edit#heading=h.7ukms7o1890s) we should have both fields for all events

[DATA-11047]: https://bigcommercecloud.atlassian.net/browse/DATA-11047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ