### PR TITLE
fix(request): add a request option that will cause 404's to throw

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -88,6 +88,13 @@ export default function (relativeUrl, opts, callback) {
 
     return fetch(url, config)
         .then((response) => {
+            if (
+              opts?.requestOptions?.is404Error === true &&
+              response.status === 404
+            ) {
+              throw new Error('404');
+            }
+
             if (response.headers.get('content-type').indexOf('application/json') !== -1) {
                 return response.json();
             }


### PR DESCRIPTION
Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)

## What/Why?

https://github.com/bigcommerce/stencil-utils/issues/214

## Rollout/Rollback

It's a non-breaking opt-in only change.

## Testing

Call the API and pass this option.