### PR TITLE
STRF-13076 - Cancel Quick Search Requests Early if New Search is Started

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -11,7 +11,6 @@ export default class extends Base {
 
         // set up class variables
         this.endpoint = '/search.php?search_query=';
-        this.abortController = new AbortController();
     }
 
     /**
@@ -21,7 +20,9 @@ export default class extends Base {
      * @param {Function} callback
      */
     search(query, params, callback) {
-        this.abortController.abort();
+        if (this.abortController) {
+            this.abortController.abort();
+        }
 
         const url = this.endpoint + encodeURIComponent(query);
         let paramsArg = params;
@@ -34,6 +35,7 @@ export default class extends Base {
 
         Hooks.emit('search-quick-remote', query);
 
+        this.abortController = new AbortController();
         paramsArg.abortSignal = this.abortController.signal;
         this.makeRequest(url, 'GET', paramsArg, false, callbackArg);
     }

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -11,6 +11,7 @@ export default class extends Base {
 
         // set up class variables
         this.endpoint = '/search.php?search_query=';
+        this.abortController = new AbortController();
     }
 
     /**
@@ -20,6 +21,8 @@ export default class extends Base {
      * @param {Function} callback
      */
     search(query, params, callback) {
+        this.abortController.abort();
+
         const url = this.endpoint + encodeURIComponent(query);
         let paramsArg = params;
         let callbackArg = callback;
@@ -30,6 +33,8 @@ export default class extends Base {
         }
 
         Hooks.emit('search-quick-remote', query);
+
+        paramsArg.abortSignal = this.abortController.signal;
         this.makeRequest(url, 'GET', paramsArg, false, callbackArg);
     }
 }

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -54,6 +54,8 @@ export default function (relativeUrl, opts, callback) {
         'x-requested-with': 'stencil-utils',
     };
 
+    const abortSignal = (options.requestOptions.abortSignal || null);
+
     if (!isValidHTTPMethod(options.method)) {
         return callback(new Error('Not a valid HTTP method'));
     }
@@ -76,6 +78,7 @@ export default function (relativeUrl, opts, callback) {
         method: options.method,
         headers,
         credentials: 'include',
+        signal: abortSignal,
     };
 
     let url = options.requestOptions.baseUrl ? `${options.requestOptions.baseUrl}${relativeUrl}` : relativeUrl;


### PR DESCRIPTION
Jira: [STRF-13076](https://bigcommercecloud.atlassian.net/browse/STRF-13076)

## What/Why?
Add `AbortController()` behavior to the `search.js` module used by quick search functionality. This will cancel search requests (GET to `/search.php?search_query=test`) early if a new search request started before the previous is finished.

## Rollout/Rollback
Revert.

## Testing
Locally.

<img width="1510" alt="Screenshot 2025-05-13 at 12 53 39 PM" src="https://github.com/user-attachments/assets/d161e699-f62e-47a2-971e-4bdd0978181f" />
I added a 9s delay into the search request route in BcApp and we can see all of the cancelled requests happening prior to that 9s. It is only the last request that I allow to complete which runs for the full duration. It responds with a 500 because I don't have the search service running but this does demonstrate the early abort behavior is running.

[STRF-13076]: https://bigcommercecloud.atlassian.net/browse/STRF-13076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ